### PR TITLE
update port model to integrate port decoder

### DIFF
--- a/bn-models/src/models/_lookups/port.ts
+++ b/bn-models/src/models/_lookups/port.ts
@@ -6,17 +6,71 @@ export const PortTypeName = 'port';
 // TODO add an at-sea transfer Port ID to DB
 
 export interface Port extends BaseLookup {
-  name?: string;
-  code?: string;
-  group?: string;
-  state?: string;
+  name?: string;  // PORT_NAME from PORTS table
+  state?: string; // STATE from PORTS table
+  pacfinPortCode: string; // PORT_CODE from PORTS table
+  pacfinPortGroupCode: string; // PCGROUP from PORT_DECODER table
+  wcgopPortGroup?: string; // PORT_GROUP from PORTS table
+  ifqPortId?: number; // not sure where this comes from
+  ifqPortCode?: number; // IFQ_PORT_CODE from PORTS table
 
   legacy?: {
-    portId?: number;
-    obsprodLoadDate?: BoatnetDate;
-
-    // Possibly legacy, unclear what these values represent.
-    ifqPortId?: number;
-    ifqPortCode?: number;
+    portId?: number; // PORT_ID from PORTS table
+    obsprodLoadDate?: BoatnetDate; // from PORTS table
   };
 }
+
+
+
+/* New Port
+
+{
+  "_id": "42e32d2f590983b0ec662157ce1f57ba",
+  "_rev": "1-e65da588c46ec95951c6157b0b9cb754",
+  "type": "port",
+  "name": "CHARLESTON (COOS BAY)",
+  "state": "OR",
+  "pacfinPortCode": "COS",
+  "pacfinPortGroupCode": "CBA",
+  "wcgopPortGroup": "CB",
+  "ifqPortId": 262,
+  "ifqPortCode": 34,
+  "createdBy": 1180,
+  "createdDate": "2000-01-03T13:54:59-08:00",
+  "updatedBy": "**** ***** (1331)",
+  "updatedDate": "2019-10-16T08:57:54-07:00",
+  "legacy": {
+    "portId": 11419,
+    "obsprodLoadDate": "Invalid date",
+  }
+
+  ...optionally:
+  isAshop: true
+  isActive: true
+}
+
+*/
+
+/* Old Port
+
+{
+  "_id": "42e32d2f590983b0ec662157ce1f57ba",
+  "_rev": "1-e65da588c46ec95951c6157b0b9cb754",
+  "type": "port",
+  "name": "CHARLESTON (COOS BAY)",
+  "code": "COS",
+  "group": "CB",
+  "state": "OR",
+  "createdBy": 1180,
+  "createdDate": "2000-01-03T13:54:59-08:00",
+  "updatedBy": "**** ***** (1331)",
+  "updatedDate": "2019-10-16T08:57:54-07:00",
+  "legacy": {
+    "portId": 11419,
+    "obsprodLoadDate": "Invalid date",
+    "ifqPortId": 262,
+    "ifqPortCode": 34
+  }
+}
+
+*/

--- a/bn-models/src/models/_lookups/port.ts
+++ b/bn-models/src/models/_lookups/port.ts
@@ -6,23 +6,23 @@ export const PortTypeName = 'port';
 // TODO add an at-sea transfer Port ID to DB
 
 export interface Port extends BaseLookup {
-  name?: string;  // PORT_NAME from PORTS table
+  name?: string;  // PORT_NAME from OBSPROD PORTS table
   state?: string; // STATE from PORTS table
   pacfinPortCode: string; // PORT_CODE from PORTS table
   pacfinPortGroupCode: string; // PCGROUP from PORT_DECODER table
   wcgopPortGroup?: string; // PORT_GROUP from PORTS table
-  ifqPortId?: number; // not sure where this comes from
-  ifqPortCode?: number; // IFQ_PORT_CODE from PORTS table
 
   legacy?: {
     portId?: number; // PORT_ID from PORTS table
+    ifqPortId?: number; // not sure where this comes from
+    ifqPortCode?: number; // IFQ_PORT_CODE from PORTS table
     obsprodLoadDate?: BoatnetDate; // from PORTS table
   };
 }
 
 
 
-/* New Port
+/* Example Doc
 
 {
   "_id": "42e32d2f590983b0ec662157ce1f57ba",
@@ -51,26 +51,3 @@ export interface Port extends BaseLookup {
 
 */
 
-/* Old Port
-
-{
-  "_id": "42e32d2f590983b0ec662157ce1f57ba",
-  "_rev": "1-e65da588c46ec95951c6157b0b9cb754",
-  "type": "port",
-  "name": "CHARLESTON (COOS BAY)",
-  "code": "COS",
-  "group": "CB",
-  "state": "OR",
-  "createdBy": 1180,
-  "createdDate": "2000-01-03T13:54:59-08:00",
-  "updatedBy": "**** ***** (1331)",
-  "updatedDate": "2019-10-16T08:57:54-07:00",
-  "legacy": {
-    "portId": 11419,
-    "obsprodLoadDate": "Invalid date",
-    "ifqPortId": 262,
-    "ifqPortCode": 34
-  }
-}
-
-*/


### PR DESCRIPTION
Trying out our proposed model change workflow.

I've updated the port model in an effort to clean up the naming and integrate the data contained in the PORT_DECODER table.

dumps of the Oracle tables can be found [PORTS](https://drive.google.com/file/d/17XhVphb5M5MMylc4svrv2OEipRjjEWwc/view?usp=sharing) and [PORT_DECODER](https://docs.google.com/spreadsheets/d/1EOihfqJNMQS1wBSyGDPYbEDO7pvMx1w5tSf7G0ur_EE/edit?usp=sharing)

@melinashak-noaa  - doesn't have to be right now, but at some point, please check with the Ashop people to understand their port needs?  Do they use the same ports we do?  Do they have their own port groupings?

Would appreciate a quick review from everyone, also, any suggestions on how this process could be fine tuned, add them as comments to the issue or bring up in the next meeting.

Thanks!