### PR TITLE
updating how we keep track of history in the catch results doc

### DIFF
--- a/bn-models/src/models/trips-api/catches.ts
+++ b/bn-models/src/models/trips-api/catches.ts
@@ -37,6 +37,7 @@ export interface Catches extends Base {
     reviewerName?: string;
     totalReviewTime?: string;
     hauls?: Haul[];
+    updatedBy?: string;
   }
 
   interface FishTicket {

--- a/bn-models/src/models/trips-api/response-catch.ts
+++ b/bn-models/src/models/trips-api/response-catch.ts
@@ -16,11 +16,15 @@ export enum WeightType {
 
 export interface CatchResults extends Base {
     tripNum?: number;
+    createDate?: string;
+    updateDate?: string;
+    updatedBy?: string;
     logbookCatch?: Record[];
     thirdPartyReviewCatch?: Record[];
     nwfscAuditCatch?: Record[];
     debitSourceCatch?: DebitSourceRecord[];
     ifqTripReporting?: IfqTripLevelRecord[];
+    revisionHistory?: RevisionHistoryItem[];
 }
 
 interface CommonRecord {
@@ -57,4 +61,9 @@ interface IfqTripLevelRecord {
     ifqGrouping?: string;
     disposition?: Disposition;
     weight?: number;
+}
+
+interface RevisionHistoryItem {
+    oldVal?: any;
+    updateDate?: string;
 }


### PR DESCRIPTION
Updating how we keep track of revision history as discussed earlier. 