### PR TITLE
modified base lookup so modifying lookups that inherit off it

### DIFF
--- a/bn-models/src/models/_base/base-lookup.ts
+++ b/bn-models/src/models/_base/base-lookup.ts
@@ -1,5 +1,6 @@
 
 import { Base } from './base';
+import { BoatnetDate } from '../_common';
 
 export interface BaseLookup extends Base  {
 
@@ -13,11 +14,16 @@ export interface BaseLookup extends Base  {
     isHakeSurvey?: boolean;
     isHookAndLineSurvey?: boolean;
     isCommon?: boolean;
-    legacy?: {
-        lookupVal?: string;
-        programId?: number;
-        lookupId?: number;
-        lookupType?: string;
-    };
+    legacy?: Legacy;
     isEM?: boolean;
+}
+
+export interface Legacy {
+    lookupVal?: number;
+    active?: boolean;
+    programId?: number;
+    sortOrder?: number;
+    lookupId?: number;
+    obsprodLoadDate?: BoatnetDate;
+    lookupType?: string;
 }

--- a/bn-models/src/models/_lookups/beaufort.ts
+++ b/bn-models/src/models/_lookups/beaufort.ts
@@ -1,19 +1,4 @@
-import { BoatnetDate } from '../_common';
 import { BaseLookup } from '../_base';
-
 export const BeaufortTypeName = 'beaufort';
 
-export interface Beaufort extends BaseLookup {
-  // description
-
-  legacy?: {
-    lookupVal?: number;
-    active?: boolean;
-    programId?: number;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-
-}
+export type Beaufort = BaseLookup;

--- a/bn-models/src/models/_lookups/behavior.ts
+++ b/bn-models/src/models/_lookups/behavior.ts
@@ -1,18 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const BehaviorTypeName = 'behavior';
 
-export interface Behavior extends BaseLookup {
-  // description
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type Behavior = BaseLookup;

--- a/bn-models/src/models/_lookups/biospecimen-sample-method.ts
+++ b/bn-models/src/models/_lookups/biospecimen-sample-method.ts
@@ -1,18 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const BiosampleSampleMethodTypeName = 'biospecimen-sample-method';
 
-export interface BiospecimenSampleMethod extends BaseLookup {
-  // description
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type BiospecimenSampleMethod = BaseLookup;

--- a/bn-models/src/models/_lookups/biostructure-type.ts
+++ b/bn-models/src/models/_lookups/biostructure-type.ts
@@ -1,18 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const BiostructureTypeTypeName = 'biostructure-type';
 
-export interface BiostructureType extends BaseLookup {
-  // description
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type BiostructureType = BaseLookup;

--- a/bn-models/src/models/_lookups/body-length.ts
+++ b/bn-models/src/models/_lookups/body-length.ts
@@ -1,18 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const BodyLengthTypeName = 'body-length';
 
-export interface BodyLength extends BaseLookup {
-  // description
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type BodyLength = BaseLookup;

--- a/bn-models/src/models/_lookups/catch-disposition.ts
+++ b/bn-models/src/models/_lookups/catch-disposition.ts
@@ -1,18 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const CatchDispositionTypeName = 'catch-disposition';
 
-export interface CatchDisposition extends BaseLookup {
-  // description
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type CatchDisposition = BaseLookup;

--- a/bn-models/src/models/_lookups/catch-grouping.ts
+++ b/bn-models/src/models/_lookups/catch-grouping.ts
@@ -1,4 +1,4 @@
-import { BaseLookup } from '../_base';
+import { BaseLookup, Legacy } from '../_base';
 import { MarineDebris } from './marine-debris';
 import { TaxonomyAlias } from './taxonomy-alias';
 
@@ -24,11 +24,13 @@ export interface CatchGrouping extends BaseLookup {
   wcrIfqSpeciesGroupId?: number;
   isInactive?: boolean;
 
-  legacy?: {
-    // ETL Note - Only for multi-species catch categories
-    wcgopCatchCategoryCode?: string;
-    wcgopCatchCategoryId?: number;
-  };
+  // ETL Note - Only for multi-species catch categories
+  legacy?: CatchGroupingLegacy;
+}
+
+interface CatchGroupingLegacy extends Legacy {
+  wcgopCatchCategoryCode?: string;
+  wcgopCatchCategoryId?: number;
 }
 
 /*

--- a/bn-models/src/models/_lookups/condition.ts
+++ b/bn-models/src/models/_lookups/condition.ts
@@ -1,12 +1,13 @@
-import { BaseLookup } from '../_base';
+import { BaseLookup, Legacy } from '../_base';
 
 export const ConditionTypeName = 'condition';
 
 export interface Condition extends BaseLookup {
   animalCode?: string; // ashop code to delineate the type of animal, pulled from animal type lookup in norpac
   animalDescription?: string; // ashop description of animal code used, pulled from animal type lookup in norpac
+  legacy?: ConditionLegacy;
+}
 
-  legacy?: {
-    conditionCode?: string;
-  };
+interface ConditionLegacy extends Legacy {
+  conditionCode?: string;
 }

--- a/bn-models/src/models/_lookups/confidence.ts
+++ b/bn-models/src/models/_lookups/confidence.ts
@@ -1,18 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const ConfidenceTypeName = 'confidence';
 
-export interface Confidence extends BaseLookup {
-  // description
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type Confidence = BaseLookup;

--- a/bn-models/src/models/_lookups/contact-category.ts
+++ b/bn-models/src/models/_lookups/contact-category.ts
@@ -1,18 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const ContactCategoryTypeName = 'contact-category';
 
-export interface ContactCategory extends BaseLookup {
-  // description
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type ContactCategory = BaseLookup;

--- a/bn-models/src/models/_lookups/contact-type.ts
+++ b/bn-models/src/models/_lookups/contact-type.ts
@@ -1,18 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const ContactTypeTypeName = 'contact-type';
 
-export interface ContactType extends BaseLookup {
-  // description
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type ContactType = BaseLookup;

--- a/bn-models/src/models/_lookups/deterrent-type.ts
+++ b/bn-models/src/models/_lookups/deterrent-type.ts
@@ -1,18 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const DeterrenceTypeTypeName = 'deterrence-type';
 
-export interface DeterrentType extends BaseLookup {
-  // description| seal bomb, firearm, gaff, yelling, acoustic device, other
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type DeterrentType = BaseLookup;

--- a/bn-models/src/models/_lookups/deterrent-type.ts
+++ b/bn-models/src/models/_lookups/deterrent-type.ts
@@ -2,3 +2,5 @@ import { BaseLookup } from '../_base';
 export const DeterrenceTypeTypeName = 'deterrence-type';
 
 export type DeterrentType = BaseLookup;
+// notes:
+// description| seal bomb, firearm, gaff, yelling, acoustic device, other

--- a/bn-models/src/models/_lookups/discard-reason.ts
+++ b/bn-models/src/models/_lookups/discard-reason.ts
@@ -1,18 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const DiscardReasonTypeName = 'discard-reason';
 
-export interface DiscardReason extends BaseLookup {
-  // description
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type DiscardReason = BaseLookup;

--- a/bn-models/src/models/_lookups/gear-performance.ts
+++ b/bn-models/src/models/_lookups/gear-performance.ts
@@ -1,17 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const GearPerformanceTypeName = 'gear-performance';
 
-export interface GearPerformance extends BaseLookup {
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type GearPerformance = BaseLookup;

--- a/bn-models/src/models/_lookups/gear-type.ts
+++ b/bn-models/src/models/_lookups/gear-type.ts
@@ -26,5 +26,4 @@ export enum GearTypes {
     LonglineSnap = "20"
 }
 
-export interface GearType extends BaseLookup {
-}
+export type GearType = BaseLookup;

--- a/bn-models/src/models/_lookups/hlfc-aerial-extent.ts
+++ b/bn-models/src/models/_lookups/hlfc-aerial-extent.ts
@@ -1,17 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const HlfcAerialExtentTypeName = 'hlfc-aerial-extent';
 
-export interface HlfcAerialExtent extends BaseLookup {
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type HlfcAerialExtent = BaseLookup;

--- a/bn-models/src/models/_lookups/hlfc-horizontal-extent.ts
+++ b/bn-models/src/models/_lookups/hlfc-horizontal-extent.ts
@@ -1,17 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const HlfcHorizontalExtentTypeName = 'hlfc-horizontal-extent';
 
-export interface HlfcHorizontalExtent extends BaseLookup {
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type HlfcHorizontalExtent = BaseLookup;

--- a/bn-models/src/models/_lookups/hlfc-mitigation-type.ts
+++ b/bn-models/src/models/_lookups/hlfc-mitigation-type.ts
@@ -1,17 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const HlfcMitigationTypeTypeName = 'hlfc-mitigation-type';
 
-export interface HlfcMitigationType extends BaseLookup {
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type HlfcMitigationType = BaseLookup;

--- a/bn-models/src/models/_lookups/hlfc-product-delivery-state.ts
+++ b/bn-models/src/models/_lookups/hlfc-product-delivery-state.ts
@@ -1,17 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const HlfcProductDeliveryStateTypeName = 'hlfc-product-delivery-state';
 
-export interface HlfcProductDeliveryState extends BaseLookup {
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type HlfcProductDeliveryState = BaseLookup;

--- a/bn-models/src/models/_lookups/interaction-outcome.ts
+++ b/bn-models/src/models/_lookups/interaction-outcome.ts
@@ -1,17 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const InteractionOutcomeTypeName = 'interaction-outcome';
 
-export interface InteractionOutcome extends BaseLookup {
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type InteractionOutcome = BaseLookup;

--- a/bn-models/src/models/_lookups/interaction-type.ts
+++ b/bn-models/src/models/_lookups/interaction-type.ts
@@ -1,17 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const InteractionTypeTypeName = 'interaction-type';
 
-export interface InteractionType extends BaseLookup {
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type InteractionType = BaseLookup;

--- a/bn-models/src/models/_lookups/maturity.ts
+++ b/bn-models/src/models/_lookups/maturity.ts
@@ -1,15 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
-
 export const MaturityTypeName = 'maturity';
 
-export interface Maturity extends BaseLookup {
-  legacy?: {
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type Maturity = BaseLookup;

--- a/bn-models/src/models/_lookups/program.ts
+++ b/bn-models/src/models/_lookups/program.ts
@@ -6,14 +6,4 @@ export const ProgramTypeName = 'program';
 export interface Program extends BaseLookup {
   name?: string;
   // description?: string;
-
-  legacy?: {
-    lookupId?: number;
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
 }

--- a/bn-models/src/models/_lookups/relationship.ts
+++ b/bn-models/src/models/_lookups/relationship.ts
@@ -1,17 +1,5 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
 
 export const RelationshipTypeName = 'relationship';
 
-export interface Relationship extends BaseLookup {
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type Relationship = BaseLookup;

--- a/bn-models/src/models/_lookups/sample-system.ts
+++ b/bn-models/src/models/_lookups/sample-system.ts
@@ -1,9 +1,11 @@
-import { BaseLookup } from '../_base';
+import { BaseLookup, Legacy } from '../_base';
 
 export const SampleSystemTypeName = 'sample-system';
 
 export interface SampleSystem extends BaseLookup {
-  legacy?: {
-    sampleSystemCode?: number;
-  };
+  legacy?: SampleSystemLegacy;
+}
+
+interface SampleSystemLegacy extends Legacy {
+  sampleSystemCode?: number;
 }

--- a/bn-models/src/models/_lookups/sighting-condition.ts
+++ b/bn-models/src/models/_lookups/sighting-condition.ts
@@ -1,17 +1,5 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
 
 export const SightingConditionTypeName = 'sighting-condition';
 
-export interface SightingCondition extends BaseLookup {
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type SightingCondition = BaseLookup;

--- a/bn-models/src/models/_lookups/species-category.ts
+++ b/bn-models/src/models/_lookups/species-category.ts
@@ -15,14 +15,4 @@ export interface SpeciesCategory extends BaseLookup {
   // description?: string;
   taxonomy?: Taxonomy; // Beth to track down
   subCategories?: SpeciesSubCategory[]; // Beth to track down
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
 }

--- a/bn-models/src/models/_lookups/species-sub-category.ts
+++ b/bn-models/src/models/_lookups/species-sub-category.ts
@@ -1,18 +1,5 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
 
 export const SpeciesSubCategoryTypeName = 'species-sub-category';
 
-export interface SpeciesSubCategory extends BaseLookup {
-  // description?: string;
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type SpeciesSubCategory = BaseLookup;

--- a/bn-models/src/models/_lookups/species.ts
+++ b/bn-models/src/models/_lookups/species.ts
@@ -1,4 +1,4 @@
-import { BaseLookup } from '../_base';
+import { BaseLookup, Legacy } from '../_base';
 import { BoatnetDate } from '../_common';
 import { SpeciesCategory } from './species-category';
 import { SpeciesSubCategory } from './species-sub-category';
@@ -10,9 +10,11 @@ export interface Species extends BaseLookup {
   commonName: string;
   pacfinCode?: string;
   isActive: boolean; // 0 if false, default to true, TODO confirm with Neil
+  legacy?: SpeciesLegacy;
+}
 
-  legacy?: {
-    raceCode?: string;
+interface SpeciesLegacy extends Legacy {
+  raceCode?: string;
     speciesCode?: string;
     speciesId?: number;
     speciesCategory?: SpeciesCategory;
@@ -21,5 +23,4 @@ export interface Species extends BaseLookup {
     bsSpecies?: boolean; // Y or NULL
     formRequired?: boolean; // Y or NULL
     obsprodLoadDate: BoatnetDate;
-  };
 }

--- a/bn-models/src/models/_lookups/third-party-reviewer.ts
+++ b/bn-models/src/models/_lookups/third-party-reviewer.ts
@@ -2,6 +2,4 @@ import { BaseLookup } from '../_base';
 
 export const ThirdPartyReviewerTypeName = 'third-party-reviewer';
 
-export interface ThirdPartyReviewer extends BaseLookup {
-    description?: string;
-  }
+export type ThirdPartyReviewer = BaseLookup;

--- a/bn-models/src/models/_lookups/trip-status.ts
+++ b/bn-models/src/models/_lookups/trip-status.ts
@@ -1,17 +1,5 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
 
 export const TripStatusTypeName = 'trip-status';
 
-export interface TripStatus extends BaseLookup {
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type TripStatus = BaseLookup;

--- a/bn-models/src/models/_lookups/vessel-logbook-type.ts
+++ b/bn-models/src/models/_lookups/vessel-logbook-type.ts
@@ -1,18 +1,5 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
 
 export const VesselLogbookTypeName = 'vessel-logbook-type';
 
-export interface VesselLogbookType extends BaseLookup {
-  // description?: string;
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type VesselLogbookType = BaseLookup;

--- a/bn-models/src/models/_lookups/vessel-status.ts
+++ b/bn-models/src/models/_lookups/vessel-status.ts
@@ -1,18 +1,5 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
 
 export const VesselStatusTypeName = 'vessel-status';
 
-export interface VesselStatus extends BaseLookup {
-  // description?: string;
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type VesselStatus = BaseLookup;

--- a/bn-models/src/models/_lookups/vessel-type.ts
+++ b/bn-models/src/models/_lookups/vessel-type.ts
@@ -1,18 +1,5 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
 
 export const VesselTypeTypeName = 'vessel-type';
 
-export interface VesselType extends BaseLookup {
-  // description?: string;
-
-  legacy?: {
-    lookupVal?: number;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type VesselType = BaseLookup;

--- a/bn-models/src/models/_lookups/viability.ts
+++ b/bn-models/src/models/_lookups/viability.ts
@@ -1,15 +1,5 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
 
 export const ViabilityTypeName = 'viability';
 
-export interface Viability extends BaseLookup {
-  legacy?: {
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type Viability = BaseLookup;

--- a/bn-models/src/models/_lookups/waiver-type.ts
+++ b/bn-models/src/models/_lookups/waiver-type.ts
@@ -1,19 +1,5 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
 
 export const WaiverTypeTypeName = 'waiver-type';
 
-export interface WaiverType extends BaseLookup {
-    // description?: string; // Trip, Selection Cycle, Coverage Period
-    // Selection Cycle = remainder of the year, remainder of 6-month cycle
-
-    legacy?: {
-      lookupVal?: number; // T, SC, CP
-      programId?: number;
-      active?: boolean;
-      sortOrder?: number;
-      lookupId?: number;
-      obsprodLoadDate?: BoatnetDate;
-      lookupType?: string;
-  };
-}
+export type WaiverType = BaseLookup;

--- a/bn-models/src/models/_lookups/waiver-type.ts
+++ b/bn-models/src/models/_lookups/waiver-type.ts
@@ -3,3 +3,7 @@ import { BaseLookup } from '../_base';
 export const WaiverTypeTypeName = 'waiver-type';
 
 export type WaiverType = BaseLookup;
+// notes:
+// description?: string; // Trip, Selection Cycle, Coverage Period
+// Selection Cycle = remainder of the year, remainder of 6-month cycle
+// lookupVal?: number; // T, SC, CP

--- a/bn-models/src/models/_lookups/weight-method.ts
+++ b/bn-models/src/models/_lookups/weight-method.ts
@@ -1,5 +1,4 @@
 import { BaseLookup } from '../_base';
-import { BoatnetDate } from '../_common';
 
 export const WeightMethodTypeName = 'weight-method';
 
@@ -18,16 +17,4 @@ export enum WeightMethodValue {
   actualWeightSubsample = 21
 }
 
-export interface WeightMethod extends BaseLookup {
-  // description?: string;
-
-  legacy?: {
-    lookupVal?: WeightMethodValue;
-    programId?: number;
-    active?: boolean;
-    sortOrder?: number;
-    lookupId?: number;
-    obsprodLoadDate?: BoatnetDate;
-    lookupType?: string;
-  };
-}
+export type WeightMethod = BaseLookup;


### PR DESCRIPTION
Went to push my changes to npm, but when I ran yarn build got errors. This was because I had an empty interface in gearPerformance since I modified baseLookup and put all the fields needed for gearPerformance in there. Changed gearPerformance to a type and now it compiles fine. Also made this same change to many other lookups that have a similar interface to the baseLookup. 